### PR TITLE
Remove stuck class for elements at the top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Elements at the top of the page must have the `stuck` class removed when scrolled back to the top.
 
 ## [0.3.2] - 2020-02-13
 ### Fixed

--- a/react/modules/useStickyScroll.ts
+++ b/react/modules/useStickyScroll.ts
@@ -42,6 +42,15 @@ export const useStickyScroll = ({
 
       if (position === Positions.TOP) {
         stuckPosition -= offset
+        /*
+         * We remove `1` from the current position because stuck elements at the top
+         * of the page must be able to be considered "unstuck".
+         * In example, a mobile header at the top of the page should be considered unstuck
+         * if the user scrolls back to the top of the page.
+         */
+        if (stuckPosition === 0 && currentPosition === 0) {
+          currentPosition -= 1
+        }
       } else {
         currentPosition += window.innerHeight
         stuckPosition += offset + contentHeight


### PR DESCRIPTION
#### What problem is this solving?

Related to:
- https://github.com/vtex-apps/store-discussion/issues/215
- https://app.clubhouse.io/vtex/story/32679/mobile-sticky-header-does-not-get-the-class-stuck-removed

#### How should this be manually tested?

1) Goto https://kiwi--storecomponents.myvtex.com/
2) See the store are a mobile device
3) Header should be not stylized as `stuck` (no shadow beneath)
4) Scroll down
5) Shadow should appear beneath the header
5) Scroll to the top again, shadow should disappear

Compare the same scenario with http://storetheme.vtex.com/

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

