### PR TITLE
Fix/layout shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevents initial overlap with content, which also prevents layout shift once the component loads.
 
 ## [0.3.3] - 2020-03-03
 ### Fixed

--- a/react/StickyLayout.tsx
+++ b/react/StickyLayout.tsx
@@ -35,7 +35,7 @@ const StickyLayoutComponent: FC<Props> = ({
   const containerRef = useRef<HTMLDivElement>(null)
 
   // Height of the sticky layout content
-  const [contentHeight, setContentHeight] = useState<number>(0)
+  const [contentHeight, setContentHeight] = useState<number | string>('auto')
   // Distance of the sticky layout wrapper to the top of the page
   const [wrapperOffsetTop, setWrapperOffsetTop] = useState<number>(0)
 
@@ -83,7 +83,7 @@ const StickyLayoutComponent: FC<Props> = ({
   const containerClassname = [
     handles.container,
     !zIndex && 'z-999',
-    isStuck ? 'fixed' : 'absolute',
+    isStuck ? 'fixed' : 'relative',
     'left-0 right-0',
   ]
     .filter(Boolean)

--- a/react/modules/useStickyScroll.ts
+++ b/react/modules/useStickyScroll.ts
@@ -34,7 +34,7 @@ export const useStickyScroll = ({
 
   const handlePosition = useCallback(
     (scrollY: number) => {
-      if (!contentHeight || typeof contentHeight !== "number") return
+      if (!contentHeight || typeof contentHeight !== 'number') return
 
       const offset = stickOffset + verticalSpacing
       let currentPosition = scrollY

--- a/react/modules/useStickyScroll.ts
+++ b/react/modules/useStickyScroll.ts
@@ -7,7 +7,7 @@ interface StickyProps {
   position?: Positions
   verticalSpacing?: number
   stickOffset?: number
-  contentHeight: number
+  contentHeight: number | string
   wrapperOffsetTop: number
 }
 
@@ -34,7 +34,7 @@ export const useStickyScroll = ({
 
   const handlePosition = useCallback(
     (scrollY: number) => {
-      if (!contentHeight) return
+      if (!contentHeight || typeof contentHeight !== "number") return
 
       const offset = stickOffset + verticalSpacing
       let currentPosition = scrollY

--- a/react/package.json
+++ b/react/package.json
@@ -19,7 +19,7 @@
     "@vtex/tsconfig": "^0.4.3",
     "apollo-cache-inmemory": "^1.6.5",
     "apollo-client": "^2.6.8",
-    "typescript": "3.7.3",
+    "typescript": "3.8.3",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.1/public/@types/vtex.css-handles",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.90.2/public/@types/vtex.render-runtime"
   },

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4480,10 +4480,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.7.3:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 typescript@^3.7.3:
   version "3.7.5"


### PR DESCRIPTION
#### What problem is this solving?
Prevents initial overlap with content, which also prevents layout shift once the component loads.

Before: (notice that the content at the bottom is pushed down after refreshing)
![sticky-before](https://user-images.githubusercontent.com/5691711/89795191-7a805300-dafe-11ea-97f4-9d6e7fba4871.gif)


After: (notice that it barely blinks after refreshing)
![sticky-after](https://user-images.githubusercontent.com/5691711/89795127-63416580-dafe-11ea-9482-d7080b87b318.gif)

<!--- What is the motivation and context for this change? -->

#### How to test it?

You can see it in action over on https://storetheme.vtex.com/?workspace=lbebbersticky1&v=05


#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
