### PR TITLE
[#1280105] Fix to prevents content overlap and layout shifting on the initial component load.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed 
+- Prevents content overlap and layout shifting on the initial component load. [Vtex Request #1280105](https://support.vtex.com/hc/en-us/requests/1280105)
 
 ## [0.3.4] - 2020-08-10
 ### Fixed

--- a/react/StickyLayout.tsx
+++ b/react/StickyLayout.tsx
@@ -37,7 +37,7 @@ const StickyLayoutComponent: FC<Props> = ({
   // Height of the sticky layout content
   const [contentHeight, setContentHeight] = useState<number | string>('auto')
   // Distance of the sticky layout wrapper to the top of the page
-  const [wrapperOffsetTop, setWrapperOffsetTop] = useState<number>(0)
+  const [wrapperOffsetTop, setWrapperOffsetTop] = useState<number | undefined>()
 
   const { stickOffset, onResize, position: positionContext } = useContext(
     StackContext

--- a/react/modules/useStickyScroll.ts
+++ b/react/modules/useStickyScroll.ts
@@ -8,7 +8,7 @@ interface StickyProps {
   verticalSpacing?: number
   stickOffset?: number
   contentHeight: number | string
-  wrapperOffsetTop: number
+  wrapperOffsetTop: number | undefined
 }
 
 /*
@@ -34,7 +34,7 @@ export const useStickyScroll = ({
 
   const handlePosition = useCallback(
     (scrollY: number) => {
-      if (!contentHeight || typeof contentHeight !== 'number') return
+      if (!contentHeight || typeof contentHeight !== 'number' || wrapperOffsetTop === undefined) return
 
       const offset = stickOffset + verticalSpacing
       let currentPosition = scrollY

--- a/react/package.json
+++ b/react/package.json
@@ -19,7 +19,7 @@
     "@vtex/tsconfig": "^0.4.3",
     "apollo-cache-inmemory": "^1.6.5",
     "apollo-client": "^2.6.8",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.1/public/@types/vtex.css-handles",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.90.2/public/@types/vtex.render-runtime"
   },

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4480,10 +4480,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typescript@^3.7.3:
   version "3.7.5"


### PR DESCRIPTION
#### What problem is this solving?

As mentioned in the [Vtex Request #1280105](https://support.vtex.com/hc/en-us/requests/1280105)
All D2C vtex stores are exeriencing an issue with the vtex.sticky-layout app 
Taking HP-UK as example (https://hotpoint.co.uk/) Landing into a prduct details page , it's observable that the product details bar is initially sticky when the page loads.. However, when you start to scroll, it returns to its proper position.

As you can see from the attached capture, the vtex.sticky-layout@0.3.4 component renders the class "wrapper--stuck" as soon as the page loads. When we start scrolling, the class disappears and the component works correctly. This behavior causes an overlap between the header and the product detail bar, but only initially when the page loads.

We (agency: Reply - IT)  analyzed the repository and noticed that in the StickyLayoutComponent, the state wrapperOffsetTop is initialized as 0. This state contains the distance of the sticky layout wrapper from the top of the page, and it's recalculated every three seconds or whenever the page is resized.

We tried changing the initial value of wrapperOffsetTop to undefined. In the useStickyScroll hook, we added a check that stops the execution of the handlePosition method if wrapperOffsetTop is undefined. We've linked it into a workspace and it seems to be working.


#### How to test it?
Here's an HP-UK PDP where you can see the issue
https://www.hotpoint.co.uk/hotpoint-antistain-washing-machine-graphite-7kg-1400rpm-a-rated-nswm-7469-gg-uk-869991678730/p

Here is the workspace where the changes are linked 
https://eusm39655--hotpointuk.myvtex.com/hotpoint-gentlepower-washing-machine-white-8kg-1400rpm-a30-h7-99-gpower-uk-859991679010/p 


#### Screenshots or example usage:

Here you can find a catpure of the issue
[Capture1](https://fromsmash.com/Registrazione-dello-schermo-2025-08-21-155939)
[Capture2](https://fromsmash.com/Registrazione-dello-schermo-2025-08-22-091720)





